### PR TITLE
Update the relative references in global.R

### DIFF
--- a/R/global.R
+++ b/R/global.R
@@ -6,8 +6,8 @@ suppressPackageStartupMessages({
   library(echarts4r)
 })
 
-source("data.R")
-source("ui.R")
-source("server.R")
+source("R/data.R")
+source("R/ui.R")
+source("R/server.R")
 
 shinyApp(ui, server)


### PR DESCRIPTION
Hey Dan,

I think the issue was with the relative references in global.R. For an R Project the working directory is always the root directory of the project, in your case where Data, R and the README live. global.R was trying to find data.R in the root directory, when it was one level down in the Data folder.

I should have sent you [this](https://martinctc.github.io/blog/rstudio-projects-and-working-directories-a-beginner%27s-guide/) before, because I think it highlights the reason for the project structure I was talking about at work last year.

This is a pull request which is basically me saying to you, as the owner of FBYM, "Hey I made these changes to fix an issue, what do you think? Would you like to include them in your copy/repo?" And if you like/agree with them, you can merge them into your work straight away.